### PR TITLE
Small code improvements

### DIFF
--- a/action.js
+++ b/action.js
@@ -20,11 +20,7 @@ function loadFile(location) {
         reject(error);
       });
     };
-    if (location.startsWith('http://')) {
-      http.get(location, httpCallback);
-    } else if (location.startsWith('https://')) {
-      https.get(location, httpCallback);
-    } else {
+    if (fs.existsSync(location)) {
       fs.readFile(location, 'utf8', (err, data) => {
         if (err) {
           reject(err);
@@ -32,6 +28,15 @@ function loadFile(location) {
           resolve(data);
         }
       });
+    } else {
+      let url = new URL(location);
+      if (url.protocol === 'http:') {
+        http.get(url, httpCallback);
+      } else if (url.protocol === 'https:') {
+        https.get(url, httpCallback);
+      } else {
+        reject(new Error('unsupported protocol'));
+      }
     }
   });
 }

--- a/action.js
+++ b/action.js
@@ -50,8 +50,11 @@ function loadData(path) {
   const rawData = fs.readFileSync(path, 'utf8');
   if (path.endsWith('.yaml') || path.endsWith('.yml')) {
     return yaml.load(rawData);
+  } else if (path.endsWith('.json')) {
+    return JSON.parse(rawData);
+  } else {
+    throw new Error('unsupported document type');
   }
-  return JSON.parse(rawData);
 }
 
 module.exports = async function action(schemaLocation, dataLocations, strict = false) {


### PR DESCRIPTION
* Use URL class for protocol parsing and throw meaningful error if protocol is unsupported
* Return better error in case of unsupported document type (not json/yaml)